### PR TITLE
Signpost Linux-specific pages, add equivalent CheriBSD link and rename feature matrix page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -8,9 +8,13 @@ brand:
   alt: Linaro logo
 pages:
   - title: Get Started
-    url: https://linux.morello-project.org/
-  - title: SDK
-    url: https://sdk.morello-project.org/
+    options:
+      - text: CheriBSD
+        url: https://www.cheribsd.org/
+      - text: Linux
+        url: https://linux.morello-project.org/
+      - text: Linux SDK
+        url: https://sdk.morello-project.org/
   - title: CHERI OS-feature matrix
     url: /cheri-feature-matrix/
   - title: Resources

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -15,8 +15,8 @@ pages:
         url: https://linux.morello-project.org/
       - text: Linux SDK
         url: https://sdk.morello-project.org/
-  - title: CHERI OS-feature matrix
-    url: /cheri-feature-matrix/
+  - title: Operating Systems
+    url: /operating-systems/
   - title: Resources
     url: /resources/
   - title: Contact

--- a/_pages/operating-systems.md
+++ b/_pages/operating-systems.md
@@ -1,11 +1,11 @@
 ---
-title: CHERI OS-feature matrix
+title: Operating Systems
 description: >-
   To find out more about the Morello Project, please get in touch!
-permalink: /cheri-feature-matrix/
+permalink: /operating-systems/
 layout: flow
 jumbotron:
-    title: CHERI OS-feature matrix
+    title: Operating Systems
     image: /assets/images/content/iStock-1147065676.jpg
 flow:
   - row: container_row


### PR DESCRIPTION
As discussed earlier today. See the commit messages for more details.

<img width="569" alt="image" src="https://github.com/MorelloProject/website/assets/816232/7a21698a-c1ce-454e-977a-892daa0abde1">